### PR TITLE
Add option to randomize only based on span

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,7 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run tests (deterministic based on span)
+      run: RUSTFLAGS='--cfg deterministic_based_on_span' cargo test --verbose
+    - name: Run tests (deterministic based on span, with sha2)
+      run: RUSTFLAGS='--cfg deterministic_based_on_span' cargo test --features sha2 --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,11 +16,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
     - name: Run tests (deterministic based on span)
-      run: RUSTFLAGS='--cfg deterministic_based_on_span' cargo test --verbose
+      run: RUSTFLAGS='--cfg deterministic_based_on_span' cargo +nightly test --verbose
     - name: Run tests (deterministic based on span, with sha2)
-      run: RUSTFLAGS='--cfg deterministic_based_on_span' cargo test --features sha2 --verbose
+      run: RUSTFLAGS='--cfg deterministic_based_on_span' cargo +nightly test --features sha2 --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     - name: Run tests (deterministic based on span)
-      run: RUSTFLAGS='--cfg deterministic_based_on_span' cargo +nightly test --verbose
-    - name: Run tests (deterministic based on span, with sha2)
-      run: RUSTFLAGS='--cfg deterministic_based_on_span' cargo +nightly test --features sha2 --verbose
+      env:
+        CONST_RANDOM_SEED: testSeed
+      run: cargo test --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ edition = "2018"
 [dependencies]
 const-random-macro = { path = "macro", version = "0.1.11"}
 proc-macro-hack = { version = "0.5" }
+
+[features]
+sha2 = ["const-random-macro/sha2"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,3 @@ edition = "2018"
 [dependencies]
 const-random-macro = { path = "macro", version = "0.1.11"}
 proc-macro-hack = { version = "0.5" }
-
-[features]
-sha2 = ["const-random-macro/sha2"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This crate provides compile time random number generation.
 This allows you to insert random constants into your code that will be auto-generated at compile time.
 
 A new value will be generated every time the file is rebuilt.
-This obviously makes the resulting binary or lib non-deterministic.
+This obviously makes the resulting binary or lib non-deterministic. (See below)
 
 # Example 
 
@@ -15,3 +15,10 @@ This works exactly as through you have called: `OsRng.gen::<u32>()` at compile t
 So for details of the random number generation, see the `rand` crates documentation.
 
 The following types are supported: u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, and isize. 
+
+# Deterministic builds
+
+Sometimes it is an advantage for build systems to be deterministic. To support this `const-random` reads the environmental
+variable `CONST_RANDOM_SEED`. If this variable is set, it will be used as the seed for the random number generation.
+Setting the same seed on a build of the same code should result in identical output.
+

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -14,5 +14,6 @@ proc-macro = true
 
 [dependencies]
 proc-macro-hack = { version = "0.5.13" }
-getrandom = "0.2"
-sha2 = { version = "0.9", optional = true, default-features = false }
+getrandom = "0.2.0"
+tiny-keccak = { version = "2.0.2", features = ["sha3"] }
+lazy_static = "1.4.0"

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -15,3 +15,4 @@ proc-macro = true
 [dependencies]
 proc-macro-hack = { version = "0.5.13" }
 getrandom = "0.2"
+sha2 = { version = "0.9", optional = true, default-features = false }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,19 +1,25 @@
+#![cfg_attr(deterministic_based_on_span, feature(proc_macro_span))]
+
 extern crate proc_macro;
 
-use getrandom;
 use proc_macro::TokenStream;
 use proc_macro_hack::proc_macro_hack;
-use std::mem;
 
 // Ideally we would use the proper interface for this through the rand crate,
 // but due to https://github.com/rust-lang/cargo/issues/5730 this leads to
 // issues for no_std crates that try to use rand themselves. So instead we skip
 // rand and generate random bytes straight from the OS.
+#[cfg(not(deterministic_based_on_span))]
 fn gen_random<T>() -> T {
     let mut out = [0u8; 16];
     getrandom::getrandom(&mut out).unwrap();
-    unsafe { mem::transmute_copy(&out) }
+    unsafe { std::mem::transmute_copy(&out) }
 }
+
+#[cfg(deterministic_based_on_span)]
+mod span;
+#[cfg(deterministic_based_on_span)]
+use crate::span::gen_random;
 
 #[proc_macro_hack]
 pub fn const_random(input: TokenStream) -> TokenStream {

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,28 +1,12 @@
-#![cfg_attr(deterministic_based_on_span, feature(proc_macro_span))]
-
 use proc_macro::*;
 use proc_macro_hack::proc_macro_hack;
-
-// Ideally we would use the proper interface for this through the rand crate,
-// but due to https://github.com/rust-lang/cargo/issues/5730 this leads to
-// issues for no_std crates that try to use rand themselves. So instead we skip
-// rand and generate random bytes straight from the OS.
-#[cfg(not(deterministic_based_on_span))]
-fn gen_random<T>() -> T {
-    let mut out = [0u8; 16];
-    getrandom::getrandom(&mut out).unwrap();
-    unsafe { std::mem::transmute_copy(&out) }
-}
+mod span;
+use crate::span::gen_random;
 
 /// Create a TokenStream of an identifier out of a string
 fn ident(ident: &str) -> TokenStream {
     TokenTree::from(Ident::new(ident, Span::call_site())).into()
 }
-
-#[cfg(deterministic_based_on_span)]
-mod span;
-#[cfg(deterministic_based_on_span)]
-use crate::span::gen_random;
 
 #[proc_macro_hack]
 pub fn const_random(input: TokenStream) -> TokenStream {

--- a/macro/src/span.rs
+++ b/macro/src/span.rs
@@ -1,6 +1,11 @@
 use proc_macro::Span;
 use std::collections::hash_map::DefaultHasher;
+use std::env;
 use std::hash::{Hash, Hasher};
+
+fn seed() -> impl Hash {
+    env::var_os("CONST_RANDOM_SEED")
+}
 
 pub(crate) fn gen_random<T: Random>() -> T {
     Random::random()
@@ -32,6 +37,7 @@ impl Random for u64 {
     fn random() -> Self {
         let span = Span::call_site();
         let mut hasher = DefaultHasher::new();
+        seed().hash(&mut hasher);
         span.source_file().path().hash(&mut hasher);
         span.start().line.hash(&mut hasher);
         span.start().column.hash(&mut hasher);
@@ -49,6 +55,7 @@ impl Random for u128 {
         span.start().column.hash(&mut hasher);
         span.start().line.hash(&mut hasher);
         span.source_file().path().hash(&mut hasher);
+        seed().hash(&mut hasher);
         let hi = hasher.finish();
 
         ((hi as u128) << 8) + lo as u128

--- a/macro/src/span.rs
+++ b/macro/src/span.rs
@@ -1,7 +1,45 @@
+use self::hash::Hasher;
 use proc_macro::Span;
-use std::collections::hash_map::DefaultHasher;
 use std::env;
-use std::hash::{Hash, Hasher};
+use std::hash::{Hash, Hasher as _};
+
+#[cfg(feature = "sha2")]
+mod hash {
+    use sha2::Digest;
+
+    pub struct Hasher(sha2::Sha256);
+
+    impl Hasher {
+        pub fn new() -> Self {
+            Hasher(Digest::new())
+        }
+
+        fn finalize(&self) -> [u8; 32] {
+            self.0.clone().finalize().into()
+        }
+
+        pub fn finish_wide(self) -> u128 {
+            let [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, ..] = self.finalize();
+            u128::from_ne_bytes([a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p])
+        }
+    }
+
+    impl std::hash::Hasher for Hasher {
+        fn finish(&self) -> u64 {
+            let [a, b, c, d, e, f, g, h, ..] = self.finalize();
+            u64::from_ne_bytes([a, b, c, d, e, f, g, h])
+        }
+
+        fn write(&mut self, bytes: &[u8]) {
+            self.0.update(bytes);
+        }
+    }
+}
+
+#[cfg(not(feature = "sha2"))]
+mod hash {
+    pub use std::collections::hash_map::DefaultHasher as Hasher;
+}
 
 fn seed() -> impl Hash {
     env::var_os("CONST_RANDOM_SEED")
@@ -13,6 +51,45 @@ pub(crate) fn gen_random<T: Random>() -> T {
 
 pub(crate) trait Random {
     fn random() -> Self;
+}
+
+fn hash_stuff() -> Hasher {
+    let span = Span::call_site();
+    let mut hasher = Hasher::new();
+    seed().hash(&mut hasher);
+    span.source_file().path().hash(&mut hasher);
+    span.start().line.hash(&mut hasher);
+    span.start().column.hash(&mut hasher);
+    hasher
+}
+
+impl Random for u64 {
+    fn random() -> Self {
+        hash_stuff().finish()
+    }
+}
+
+impl Random for u128 {
+    #[cfg(feature = "sha2")]
+    fn random() -> Self {
+        hash_stuff().finish_wide()
+    }
+
+    #[cfg(not(feature = "sha2"))]
+    fn random() -> Self {
+        let [a, b, c, d, e, f, g, h] = u64::random().to_ne_bytes();
+
+        // Hash the same stuff in a different order.
+        let span = Span::call_site();
+        let mut hasher = Hasher::new();
+        span.start().column.hash(&mut hasher);
+        span.start().line.hash(&mut hasher);
+        span.source_file().path().hash(&mut hasher);
+        seed().hash(&mut hasher);
+        let [i, j, k, l, m, n, o, p] = hasher.finish().to_ne_bytes();
+
+        u128::from_ne_bytes([a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p])
+    }
 }
 
 impl Random for u8 {
@@ -30,35 +107,6 @@ impl Random for u16 {
 impl Random for u32 {
     fn random() -> Self {
         u64::random() as u32
-    }
-}
-
-impl Random for u64 {
-    fn random() -> Self {
-        let span = Span::call_site();
-        let mut hasher = DefaultHasher::new();
-        seed().hash(&mut hasher);
-        span.source_file().path().hash(&mut hasher);
-        span.start().line.hash(&mut hasher);
-        span.start().column.hash(&mut hasher);
-        hasher.finish()
-    }
-}
-
-impl Random for u128 {
-    fn random() -> Self {
-        let [a, b, c, d, e, f, g, h] = u64::random().to_ne_bytes();
-
-        // Hash the same stuff in a different order.
-        let span = Span::call_site();
-        let mut hasher = DefaultHasher::new();
-        span.start().column.hash(&mut hasher);
-        span.start().line.hash(&mut hasher);
-        span.source_file().path().hash(&mut hasher);
-        seed().hash(&mut hasher);
-        let [i, j, k, l, m, n, o, p] = hasher.finish().to_ne_bytes();
-
-        u128::from_ne_bytes([a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p])
     }
 }
 

--- a/macro/src/span.rs
+++ b/macro/src/span.rs
@@ -47,7 +47,7 @@ impl Random for u64 {
 
 impl Random for u128 {
     fn random() -> Self {
-        let lo = u64::random();
+        let [a, b, c, d, e, f, g, h] = u64::random().to_ne_bytes();
 
         // Hash the same stuff in a different order.
         let span = Span::call_site();
@@ -56,9 +56,9 @@ impl Random for u128 {
         span.start().line.hash(&mut hasher);
         span.source_file().path().hash(&mut hasher);
         seed().hash(&mut hasher);
-        let hi = hasher.finish();
+        let [i, j, k, l, m, n, o, p] = hasher.finish().to_ne_bytes();
 
-        ((hi as u128) << 8) + lo as u128
+        u128::from_ne_bytes([a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p])
     }
 }
 

--- a/macro/src/span.rs
+++ b/macro/src/span.rs
@@ -1,13 +1,13 @@
 use proc_macro::Span;
-use std::env;
+use std::option_env;
 
 use lazy_static::lazy_static;
 use tiny_keccak::{Hasher, Sha3};
 
 lazy_static! {
     static ref SEED: Vec<u8> = {
-        if let Some(value) = env::var_os("CONST_RANDOM_SEED") {
-            value.to_str().expect("CONST_RANDOM_SEED environmental variable contains non-unicode characters").as_bytes().to_vec()
+        if let Some(value) = option_env!("CONST_RANDOM_SEED") {
+            value.as_bytes().to_vec()
         } else {
             let mut value = [0u8; 32];
             getrandom::getrandom(&mut value).unwrap();

--- a/macro/src/span.rs
+++ b/macro/src/span.rs
@@ -1,0 +1,86 @@
+use proc_macro::Span;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+pub(crate) fn gen_random<T: Random>() -> T {
+    Random::random()
+}
+
+pub(crate) trait Random {
+    fn random() -> Self;
+}
+
+impl Random for u8 {
+    fn random() -> Self {
+        u64::random() as u8
+    }
+}
+
+impl Random for u16 {
+    fn random() -> Self {
+        u64::random() as u16
+    }
+}
+
+impl Random for u32 {
+    fn random() -> Self {
+        u64::random() as u32
+    }
+}
+
+impl Random for u64 {
+    fn random() -> Self {
+        let span = Span::call_site();
+        let mut hasher = DefaultHasher::new();
+        span.source_file().path().hash(&mut hasher);
+        span.start().line.hash(&mut hasher);
+        span.start().column.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+impl Random for u128 {
+    fn random() -> Self {
+        let lo = u64::random();
+
+        // Hash the same stuff in a different order.
+        let span = Span::call_site();
+        let mut hasher = DefaultHasher::new();
+        span.start().column.hash(&mut hasher);
+        span.start().line.hash(&mut hasher);
+        span.source_file().path().hash(&mut hasher);
+        let hi = hasher.finish();
+
+        ((hi as u128) << 8) + lo as u128
+    }
+}
+
+impl Random for i8 {
+    fn random() -> Self {
+        i64::random() as i8
+    }
+}
+
+impl Random for i16 {
+    fn random() -> Self {
+        i64::random() as i16
+    }
+}
+
+impl Random for i32 {
+    fn random() -> Self {
+        i64::random() as i32
+    }
+}
+
+impl Random for i64 {
+    fn random() -> Self {
+        u64::random() as i64
+    }
+}
+
+impl Random for i128 {
+    fn random() -> Self {
+        u128::random() as i128
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,5 @@ use proc_macro_hack::proc_macro_hack;
 ///
 /// The following types are supported u8, u16, u32, u64, and u128
 ///
-#[proc_macro_hack]
+#[proc_macro_hack(fake_call_site)]
 pub use const_random_macro::const_random;


### PR DESCRIPTION
This crate has been causing mischief in my Buck-based codebase that uses distributed caching of build artifacts. In particular, distributed build caches incorporate an assumption that build outputs are a deterministic function of the inputs. When this is not the case, it can cause a mismatch between what we think should be in cache vs what can actually be retrieved from the cache by content hash.

I am interested in fixing this while still preserving the intent of the crate, rather than e.g. `return 4;`. So this PR introduces a cfg called `deterministic_based_on_span` which causes the value emitted by const_random to be a deterministic hash based on the call site's [proc_macro::Span](https://doc.rust-lang.org/proc_macro/struct.Span.html).

This is implemented using a rustc cfg rather than a Cargo feature because it isn't something that downstream code should be allowed to enable/disable. It is a property that the build environment decides.

<br>

Tested with:

```rust
use const_random::const_random;

fn main() {
    const RANDOM: (u32, u32) = (const_random!(u32), const_random!(u32));
    println!("{:?}", RANDOM);
}
```

which prints:

```console
(3560837894, 4282915628)
```