### PR TITLE
Add targets and Cargo.lock to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock


### PR DESCRIPTION
This avoids leaving the repo dirty after a `cargo build`.