### PR TITLE
Require proc-macro-hack 0.5.13

### DIFF
--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -13,5 +13,5 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-proc-macro-hack = { version = "0.5" }
+proc-macro-hack = { version = "0.5.13" }
 getrandom = "0.1"


### PR DESCRIPTION
This drops syn/quote from the dependency tree for those of us silly enough to be using minimal-versions.

Note that the dependency on `proc-macro-hack = "0.5"` is not minimal-versions correct;
proc-macro-hack is not minimal-versions correct until 0.5.7.

<details><summary>notes</summary>

This isn't blocking minimal-version correctness for me -- constrandom actually got dropped from the dependency tree of the crate where I found this, as it wasn't a necessary dependency at all -- but it is definitely better to be more correct here.

You could instead just bump the dep to 0.5.7, as that is the first version that works.