### PR TITLE
feat: Add unique const random

### DIFF
--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -4,7 +4,7 @@ extern crate proc_macro;
 use proc_macro::*;
 use proc_macro_hack::proc_macro_hack;
 mod span;
-use crate::span::gen_random;
+use crate::span::{gen_random, gen_random_unique};
 
 /// Create a TokenStream of an identifier out of a string
 fn ident(ident: &str) -> TokenStream {
@@ -34,6 +34,41 @@ pub fn const_random(input: TokenStream) -> TokenStream {
         }
         "isize" => {
             let value: TokenStream = TokenTree::from(Literal::i128_suffixed(gen_random())).into();
+            let type_cast: TokenStream = [value, ident("as"), ident("isize")]
+                .iter()
+                .cloned()
+                .collect();
+            TokenTree::from(Group::new(Delimiter::Parenthesis, type_cast)).into()
+        }
+        _ => panic!("Invalid integer type"),
+    }
+}
+
+#[proc_macro_hack]
+pub fn const_random_unique(input: TokenStream) -> TokenStream {
+    match &input.to_string()[..] {
+        "u8" => TokenTree::from(Literal::u8_suffixed(gen_random_unique())).into(),
+        "u16" => TokenTree::from(Literal::u16_suffixed(gen_random_unique())).into(),
+        "u32" => TokenTree::from(Literal::u32_suffixed(gen_random_unique())).into(),
+        "u64" => TokenTree::from(Literal::u64_suffixed(gen_random_unique())).into(),
+        "u128" => TokenTree::from(Literal::u128_suffixed(gen_random_unique())).into(),
+        "i8" => TokenTree::from(Literal::i8_suffixed(gen_random_unique())).into(),
+        "i16" => TokenTree::from(Literal::i16_suffixed(gen_random_unique())).into(),
+        "i32" => TokenTree::from(Literal::i32_suffixed(gen_random_unique())).into(),
+        "i64" => TokenTree::from(Literal::i64_suffixed(gen_random_unique())).into(),
+        "i128" => TokenTree::from(Literal::i128_suffixed(gen_random_unique())).into(),
+        "usize" => {
+            let value: TokenStream =
+                TokenTree::from(Literal::u128_suffixed(gen_random_unique())).into();
+            let type_cast: TokenStream = [value, ident("as"), ident("usize")]
+                .iter()
+                .cloned()
+                .collect();
+            TokenTree::from(Group::new(Delimiter::Parenthesis, type_cast)).into()
+        }
+        "isize" => {
+            let value: TokenStream =
+                TokenTree::from(Literal::i128_suffixed(gen_random_unique())).into();
             let type_cast: TokenStream = [value, ident("as"), ident("isize")]
                 .iter()
                 .cloned()

--- a/macro/src/span.rs
+++ b/macro/src/span.rs
@@ -1,5 +1,5 @@
 use proc_macro::Span;
-use std::option_env;
+use std::{collections::HashSet, option_env, sync::Mutex};
 
 use lazy_static::lazy_static;
 use tiny_keccak::{Hasher, Sha3};
@@ -14,14 +14,29 @@ lazy_static! {
             value.to_vec()
         }
     };
+    static ref EXISTINGS_U8: Mutex<HashSet<u8>> = Mutex::new(HashSet::new());
+    static ref EXISTINGS_U16: Mutex<HashSet<u16>> = Mutex::new(HashSet::new());
+    static ref EXISTINGS_U32: Mutex<HashSet<u32>> = Mutex::new(HashSet::new());
+    static ref EXISTINGS_U64: Mutex<HashSet<u64>> = Mutex::new(HashSet::new());
+    static ref EXISTINGS_U128: Mutex<HashSet<u128>> = Mutex::new(HashSet::new());
+    static ref EXISTINGS_I8: Mutex<HashSet<i8>> = Mutex::new(HashSet::new());
+    static ref EXISTINGS_I16: Mutex<HashSet<i16>> = Mutex::new(HashSet::new());
+    static ref EXISTINGS_I32: Mutex<HashSet<i32>> = Mutex::new(HashSet::new());
+    static ref EXISTINGS_I64: Mutex<HashSet<i64>> = Mutex::new(HashSet::new());
+    static ref EXISTINGS_I128: Mutex<HashSet<i128>> = Mutex::new(HashSet::new());
 }
 
 pub(crate) fn gen_random<T: Random>() -> T {
     Random::random()
 }
 
+pub(crate) fn gen_random_unique<T: Random>() -> T {
+    Random::random_unique()
+}
+
 pub(crate) trait Random {
     fn random() -> Self;
+    fn random_unique() -> Self;
 }
 
 fn hash_stuff() -> impl Hasher {
@@ -38,6 +53,20 @@ impl Random for u64 {
         hash_stuff().finalize(&mut output);
         Self::from_ne_bytes(output)
     }
+
+    fn random_unique() -> Self {
+        let mut output = [0; 8];
+        let mut existings = EXISTINGS_U64.lock().unwrap();
+        loop {
+            hash_stuff().finalize(&mut output);
+            let result = Self::from_ne_bytes(output);
+            if existings.insert(result) {
+                return result;
+            } else {
+                continue;
+            }
+        }
+    }
 }
 
 impl Random for u128 {
@@ -46,11 +75,37 @@ impl Random for u128 {
         hash_stuff().finalize(&mut output);
         Self::from_ne_bytes(output)
     }
+
+    fn random_unique() -> Self {
+        let mut output = [0; 16];
+        let mut existings = EXISTINGS_U128.lock().unwrap();
+        loop {
+            hash_stuff().finalize(&mut output);
+            let result = Self::from_ne_bytes(output);
+            if existings.insert(result) {
+                return result;
+            } else {
+                continue;
+            }
+        }
+    }
 }
 
 impl Random for u8 {
     fn random() -> Self {
         u64::random() as u8
+    }
+
+    fn random_unique() -> Self {
+        let mut existings = EXISTINGS_U8.lock().unwrap();
+        loop {
+            let result = u64::random() as u8;
+            if existings.insert(result) {
+                return result;
+            } else {
+                continue;
+            }
+        }
     }
 }
 
@@ -58,11 +113,35 @@ impl Random for u16 {
     fn random() -> Self {
         u64::random() as u16
     }
+
+    fn random_unique() -> Self {
+        let mut existings = EXISTINGS_U16.lock().unwrap();
+        loop {
+            let result = u64::random() as u16;
+            if existings.insert(result) {
+                return result;
+            } else {
+                continue;
+            }
+        }
+    }
 }
 
 impl Random for u32 {
     fn random() -> Self {
         u64::random() as u32
+    }
+
+    fn random_unique() -> Self {
+        let mut existings = EXISTINGS_U32.lock().unwrap();
+        loop {
+            let result = u64::random() as u32;
+            if existings.insert(result) {
+                return result;
+            } else {
+                continue;
+            }
+        }
     }
 }
 
@@ -70,11 +149,35 @@ impl Random for i8 {
     fn random() -> Self {
         i64::random() as i8
     }
+
+    fn random_unique() -> Self {
+        let mut existings = EXISTINGS_I8.lock().unwrap();
+        loop {
+            let result = i64::random() as i8;
+            if existings.insert(result) {
+                return result;
+            } else {
+                continue;
+            }
+        }
+    }
 }
 
 impl Random for i16 {
     fn random() -> Self {
         i64::random() as i16
+    }
+
+    fn random_unique() -> Self {
+        let mut existings = EXISTINGS_I16.lock().unwrap();
+        loop {
+            let result = i64::random() as i16;
+            if existings.insert(result) {
+                return result;
+            } else {
+                continue;
+            }
+        }
     }
 }
 
@@ -82,16 +185,52 @@ impl Random for i32 {
     fn random() -> Self {
         i64::random() as i32
     }
+
+    fn random_unique() -> Self {
+        let mut existings = EXISTINGS_I32.lock().unwrap();
+        loop {
+            let result = i64::random() as i32;
+            if existings.insert(result) {
+                return result;
+            } else {
+                continue;
+            }
+        }
+    }
 }
 
 impl Random for i64 {
     fn random() -> Self {
         u64::random() as i64
     }
+
+    fn random_unique() -> Self {
+        let mut existings = EXISTINGS_I64.lock().unwrap();
+        loop {
+            let result = u64::random() as i64;
+            if existings.insert(result) {
+                return result;
+            } else {
+                continue;
+            }
+        }
+    }
 }
 
 impl Random for i128 {
     fn random() -> Self {
         u128::random() as i128
+    }
+
+    fn random_unique() -> Self {
+        let mut existings = EXISTINGS_I128.lock().unwrap();
+        loop {
+            let result = u128::random() as i128;
+            if existings.insert(result) {
+                return result;
+            } else {
+                continue;
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,10 @@ use proc_macro_hack::proc_macro_hack;
 /// const MY_RANDOM_NUMBER: u32 = const_random!(u32);
 /// ```
 ///
-/// The following types are supported u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, and isize. 
+/// The following types are supported u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, and isize.
 ///
 #[proc_macro_hack(fake_call_site)]
 pub use const_random_macro::const_random;
+
+#[proc_macro_hack(fake_call_site)]
+pub use const_random_macro::const_random_unique;


### PR DESCRIPTION
The original implementation does not guarantee the generated number to be unique. This may cause problem when using it directly as a compile-time generated identifier.
So I added a unique version to make sure when a duplicate number is generated, it would simply re-generate it, until all possible values have been taken.