### PR TITLE
Use native #[proc_macro] support if rustc is new enough

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,5 +12,5 @@ use proc_macro_hack::proc_macro_hack;
 ///
 /// The following types are supported u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, and isize. 
 ///
-#[proc_macro_hack(fake_call_site)]
+#[proc_macro_hack(fake_call_site, only_hack_old_rustc)]
 pub use const_random_macro::const_random;


### PR DESCRIPTION
According to its own readme, the proc-macro-hack crate was superseded by native support for `#[proc_macro]` in expression position in Rust 1.45. Besides that, proc-macro-hack is known to cause issues with rust-analyzer, a popular language server for Rust. A somewhat important consequence of these issues is that using the `const_random` macro makes Rust Analyzer yield an spurious "unresolved macro" error, which is annoying.

To improve on this situation without explicitly bumping MSRV, let's use native rustc support when available. This can slightly modify the macro hygiene, although I didn't notice any glaring difference.

Related Rust Analyzer project issues and PRs:
https://github.com/rust-analyzer/rust-analyzer/issues/7221
https://github.com/rust-analyzer/rust-analyzer/pull/9128