### PR TITLE
feat: Generate constant random byte arrays

### DIFF
--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -15,5 +15,5 @@ proc-macro = true
 [dependencies]
 proc-macro-hack = { version = "0.5.13" }
 getrandom = "0.2.0"
-tiny-keccak = { version = "2.0.2", features = ["sha3"] }
+tiny-keccak = { version = "2.0.2", features = ["shake"] }
 lazy_static = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@ use proc_macro_hack::proc_macro_hack;
 /// ```
 /// use const_random::const_random  ;
 /// const MY_RANDOM_NUMBER: u32 = const_random!(u32);
+/// const MY_RANDOM_BYTES: [u8; 32] = const_random!([u8; 32]);
 /// ```
 ///
-/// The following types are supported u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, and isize. 
-///
+/// The following types are supported u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, isize and [u8; N].
 #[proc_macro_hack(fake_call_site)]
 pub use const_random_macro::const_random;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -46,3 +46,12 @@ fn suffixed() {
     }
     f(const_random!(u8));
 }
+
+#[test]
+fn array() {
+    const VALUE1: &[u8] = &const_random!([u8; 30]);
+    const VALUE2: [u8; 30] = const_random!([u8; 30]);
+    assert_ne!([0u8; 30], VALUE1);
+    assert_ne!([0u8; 30], VALUE2);
+    assert_ne!(VALUE1, VALUE2);
+}


### PR DESCRIPTION
The `const_random` macro will now accept and generate fixed sized `u8`
arrays of any size. #22 

Implementation detail: This patch replaces the 256 bit fixed sized sha3
hash (SHA3-256) with the sha3 eXtendable-Output Function (SHAKE256).
This is to allow
arbitrarily long byte arrays to be generated. Replacing SHA3-245 is not strictly
necessary because the `tiny-keccak` crate does not limit the output size of sha3
functions, but I feel that misusing crypto primitives is a code smell.
