### PR TITLE
Use once_cell instead of lazy_static

### DIFF
--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -16,4 +16,4 @@ proc-macro = true
 proc-macro-hack = { version = "0.5.13" }
 getrandom = "0.2.0"
 tiny-keccak = { version = "2.0.2", features = ["sha3"] }
-lazy_static = "1.4.0"
+once_cell = "1"

--- a/macro/src/span.rs
+++ b/macro/src/span.rs
@@ -1,20 +1,18 @@
 use proc_macro::Span;
 use std::option_env;
 
-use lazy_static::lazy_static;
+use once_cell::sync::Lazy;
 use tiny_keccak::{Hasher, Sha3};
 
-lazy_static! {
-    static ref SEED: Vec<u8> = {
-        if let Some(value) = option_env!("CONST_RANDOM_SEED") {
-            value.as_bytes().to_vec()
-        } else {
-            let mut value = [0u8; 32];
-            getrandom::getrandom(&mut value).unwrap();
-            value.to_vec()
-        }
-    };
-}
+static SEED: Lazy<Vec<u8>> = Lazy::new(|| {
+    if let Some(value) = option_env!("CONST_RANDOM_SEED") {
+        value.as_bytes().to_vec()
+    } else {
+        let mut value = [0u8; 32];
+        getrandom::getrandom(&mut value).unwrap();
+        value.to_vec()
+    }
+});
 
 pub(crate) fn gen_random<T: Random>() -> T {
     Random::random()


### PR DESCRIPTION
`lazy_static` is host to a number of bad design patterns. Namely, any other crate in the dependency graph can force `lazy_static` to fall back on a spinlock-oriented approach through feature unification. In addition, it uses an opaque macro, `static mut`, and overall takes longer to compile than `once_cell`. The Rust ecosystem as a whole is migrating to `once_cell` to avoid these design flaws.

As this crate is depended on by `ahash` which, in turn, is depended on by many other crates in the Rust ecosystem, it would be beneficial if it no longer depended on `lazy_static`. In fact, for one of my projects, it is the only time `lazy_static` appears in the dependency graph. This crate replaces the one time that `lazy_static` is used, storing and caching the RNG seed, with a `once_cell::sync::Lazy`.