### PR TITLE
add #![no_std]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![no_std]
 /// # Random constants
 /// Allows you to insert random constants into your code that will be auto-generated at compile time.
 /// A new value will be generated every time the relevent file is re-built.


### PR DESCRIPTION
Hi, total Rust noobie here; please assume the worst.

Does it make sense to add `#![no_std]` to this lib? Adding this doesn't seem to make any tests in this lib to fail, and there seems to be previous discussions in this repo suggesting that `no_std` is a goal.

The reason I ask is because I'm getting the following error in [a downstream dep, Burn](https://github.com/burn-rs/burn/actions/runs/6619842817/job/17981117806?pr=893#step:10:234):

```
  = note: `std` is required by `const_random` because it does not declare `#![no_std]`
```

Cloning `constrandom` to my local machine, updating Burn's `Cargo.toml` to

```
const-random = { path = "../constrandom" }
```

and running the failing CI's command (`cargo build -p burn --no-default-features --target wasm32-unknown-unknown --color=always`) works on my local machine (when previously I could replicate the failure locally).