### PR TITLE
chore: Update getrandom dependency to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-random"
-version = "0.1.18"
+version = "0.1.19"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tkaitchuck/constrandom"
 documentation = "https://docs.rs/const-random"
@@ -11,4 +11,4 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-const-random-macro = { path = "macro", version = "0.1.16"}
+const-random-macro = { path = "macro", version = "0.1.17"}

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const-random-macro"
-version = "0.1.16"
+version = "0.1.17"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/tkaitchuck/constrandom"
 documentation = "https://docs.rs/const-random"
@@ -13,6 +13,6 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-getrandom = "0.2.0"
+getrandom = "0.4"
 tiny-keccak = { version = "2.0.2", features = ["shake"] }
 once_cell = { version = "1.15", default-features = false, features = ["race", "alloc"] }

--- a/macro/src/span.rs
+++ b/macro/src/span.rs
@@ -12,7 +12,7 @@ fn get_seed() -> &'static [u8] {
             Box::new(value.as_bytes().to_vec())
         } else {
             let mut value = [0u8; 32];
-            getrandom::getrandom(&mut value).unwrap();
+            getrandom::fill(&mut value).unwrap();
             Box::new(value.to_vec())
         }
     })[..]


### PR DESCRIPTION
This takes #37 a step further and updates `getrandom` to 0.4.

This lets me pass `--cfg getrandom_backend="windows_legacy"` via RUSTFLAGS, which is not possible in 0.3.x.